### PR TITLE
update how filter and sort are parsed

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -7,6 +7,7 @@ use Illumintae\Validation\ValidationException;
 use App\Http\Builders\ResponseBuilder;
 use App\Http\Models\Report;
 use App\Http\Services\ReportService;
+use App\Http\Utils\RequestParser;
 
 class ReportController extends Controller
 {
@@ -55,7 +56,11 @@ class ReportController extends Controller
         $responseBuilder = new ResponseBuilder();
         $page = $request->input('page') ?: 1;
         $limit = $request->input('limit') ?: 10;
-        $report = $this->service->get($page, $limit);
+        $filter = $request->input('filters') ?: [];
+        $filters = RequestParser::parseFilter($filter);
+        $sort = $request->input('sort') ?: ['updated_at', 'DESC'];
+        $sorts = RequestParser::parseSort($sort);
+        $report = $this->service->get($page, $limit, $filters, $sorts);
         $response = $responseBuilder->setData($report['data'])->setMessage('fetched report successful')
             ->setTotal($report['total'])->setCount($limit)->setPage($page)
             ->setSuccess(true)->build();

--- a/app/Http/Services/BaseService.php
+++ b/app/Http/Services/BaseService.php
@@ -14,7 +14,8 @@ class BaseService {
   }
 
   /**
-   * get get all row paginated
+   * get get all row paginated. Built resource url are: 
+   * /resource?filters[key]=value&filters[keyA]=valueA&sort=-Field
    * @param $page Integer page number
    * @param $limit Integer maximum number of item to return
    * @param $condition [Array] conditional : ex: [["name", "Andy"], ["category_id", 1]]

--- a/app/Http/Utils/RequestParser.php
+++ b/app/Http/Utils/RequestParser.php
@@ -1,0 +1,49 @@
+<?php 
+
+namespace App\Http\Utils;
+
+/**
+ * RequestParser Utility
+ */
+class RequestParser {
+
+  // request example
+  // /resource?filters[a]=a&filters[date][between]=dateFrom, dateTo&filters[price][<=]=100
+  // /resource?sort=-price or /resource?sort=price => - indicate descending sorting, while the first one indicate ascending sorting 
+
+  /**
+   * parseFilter parse filter passed via the query-string
+   * @param $filter Array
+   * @return filter
+   */
+  static public function parseFilter($filter) {
+    $filters = [];
+    array_walk($filter, function ($value, $key) use (&$filters) {
+      if (is_array($value)) {
+        $k = key($value); // second array key
+        if (key($value) == 'between') {
+          $dates = explode(', ', $value[$k]);
+          array_push($filters, [$key, '>=', $dates[0]]); // from
+          array_push($filters, [$key, '<=', $dates[1]]); // to
+        } else {
+          array_push($filters, [$key, $k, $value[$k]]);
+        }
+      } else {
+        array_push($filters, [$key, $value]);
+      }
+    });
+    return $filters;
+  }
+
+  /**
+   * parseSort parse sort passed via query-string
+   * @param $sort array
+   * @return sort
+   */
+  static public function parseSort($sort) {
+    if ($sort[0] == '-') {
+      return [substr($sort, 1), 'DESC'];
+    }
+    return [$sort, 'ASC'];
+  }
+}


### PR DESCRIPTION
### Description

Add generic `sort` and `filter` parser

### Breakdown:

- [x] default sort report by updated_at
- [x] add generic sort, filter parser

filter usage:
```
{{Host}}/reports?filters[author_id]=1&filters[report_date][between]=2019-03-30, 2019-05-31&sort=-author_id
```